### PR TITLE
Implement basic authentication views and middleware

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,5 @@
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Se connecter</button>
+</form>

--- a/templates/logout.html
+++ b/templates/logout.html
@@ -1,0 +1,4 @@
+<form method="post">
+    {% csrf_token %}
+    <button type="submit">Se déconnecter</button>
+</form>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,0 +1,5 @@
+<header>
+{% if request.user.is_authenticated %}
+    <p>Rôle : {{ request.user.role }}</p>
+{% endif %}
+</header>

--- a/ui/middleware.py
+++ b/ui/middleware.py
@@ -1,0 +1,15 @@
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+class LoginRequiredMiddleware:
+    """Redirect anonymous users to the login page."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        login_url = reverse('login')
+        if not request.user.is_authenticated and request.path != login_url:
+            return redirect(login_url)
+        return self.get_response(request)

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,0 +1,38 @@
+from django.contrib import messages
+from django.contrib.auth import login, logout
+from django.contrib.auth.forms import AuthenticationForm
+from django.shortcuts import redirect, render
+from django.views.decorators.csrf import csrf_protect
+
+ROLE_REDIRECTS = {
+    'admin': 'admin_dashboard',
+    'manager': 'manager_dashboard',
+}
+
+
+@csrf_protect
+def login_view(request):
+    """Authenticate the user and redirect based on their role."""
+    if request.method == 'POST':
+        form = AuthenticationForm(request, data=request.POST)
+        if form.is_valid():
+            user = form.get_user()
+            login(request, user)
+            messages.success(request, 'Connexion réussie.')
+            role = getattr(user, 'role', '')
+            target = ROLE_REDIRECTS.get(role, 'home')
+            return redirect(target)
+        messages.error(request, 'Identifiants invalides.')
+    else:
+        form = AuthenticationForm()
+    return render(request, 'login.html', {'form': form})
+
+
+@csrf_protect
+def logout_view(request):
+    """Log the user out and return to the login page."""
+    if request.method == 'POST':
+        logout(request)
+        messages.info(request, 'Déconnexion réussie.')
+        return redirect('login')
+    return render(request, 'logout.html')

--- a/urls.py
+++ b/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from ui.views import login_view, logout_view
+
+urlpatterns = [
+    path('login', login_view, name='login'),
+    path('logout', logout_view, name='logout'),
+]


### PR DESCRIPTION
## Summary
- add CSRF-protected login and logout views with messages and role redirects
- route /login and /logout endpoints
- add middleware forcing login and show active role in header

## Testing
- `python -m py_compile urls.py ui/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bce83dc20832d842b81306c19f022